### PR TITLE
Curate experiments: 5 new studies, per-experiment MDX write-ups

### DIFF
--- a/app/experiments/[slug]/page.tsx
+++ b/app/experiments/[slug]/page.tsx
@@ -1,17 +1,56 @@
-import ExperimentArticle from "@/content/experiments/article.mdx";
+import type { Metadata } from "next";
 import Footer from "@/components/sections/Footer";
 import ThemeToggle from "@/components/ui/ThemeToggle";
+import {
+  ExperimentDetailPage,
+  ExperimentArticle,
+  getExperimentBySlug,
+  EXPERIMENT_SLUGS,
+} from "@/components/sections/Experiments";
+import { experimentContent } from "@/content/experiments/registry";
 
 type ExperimentRouteProps = {
   params: { slug: string };
 };
 
-export default function ExperimentRoute({ params }: ExperimentRouteProps) {
+export async function generateStaticParams() {
+  return Object.values(EXPERIMENT_SLUGS).map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: ExperimentRouteProps): Promise<Metadata> {
+  const exp = getExperimentBySlug(params.slug);
+  if (!exp) return {};
+  return {
+    title: `${exp.name} — Tatenda Chinyamakobvu`,
+    description: exp.desc,
+  };
+}
+
+export default async function ExperimentRoute({
+  params,
+}: ExperimentRouteProps) {
+  const loader = experimentContent[params.slug];
+
+  const inner = loader ? (
+    await (async () => {
+      const { default: Content } = await loader();
+      return (
+        <ExperimentArticle slug={params.slug}>
+          <Content />
+        </ExperimentArticle>
+      );
+    })()
+  ) : (
+    <ExperimentDetailPage slug={params.slug} />
+  );
+
   return (
     <>
       <div className="wrap exp-route-wrap">
         <ThemeToggle />
-        <ExperimentArticle slug={params.slug} />
+        {inner}
       </div>
       <div className="wrap">
         <Footer />

--- a/app/experiments/page.tsx
+++ b/app/experiments/page.tsx
@@ -7,7 +7,7 @@ import Footer from "@/components/sections/Footer";
 export const metadata: Metadata = {
   title: "Experiments - Tatenda Chinyamakobvu",
   description:
-    "19 interactive UI experiments: CSS animations, physics simulations, and interaction patterns.",
+    "18 interactive UI studies: spring physics, perceptual color, fluid typography, and interaction patterns.",
 };
 
 export default function ExperimentsPage() {

--- a/app/globals.css
+++ b/app/globals.css
@@ -595,6 +595,71 @@ footer a:hover { color: var(--fg-muted); }
   color: var(--fg-muted);
   font-size: 15px;
 }
+
+/* MDX prose inside experiment articles */
+.exp-mdx-body p {
+  font-size: 15px;
+  line-height: 1.75;
+  color: var(--fg-muted);
+  max-width: 64ch;
+}
+.exp-mdx-body p strong {
+  color: var(--fg);
+  font-weight: 500;
+}
+.exp-mdx-body code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: var(--fg);
+}
+.exp-mdx-body pre {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--fg);
+  max-width: 100%;
+}
+.exp-mdx-body pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+.exp-mdx-body h2 {
+  font-size: 17px;
+  font-weight: 500;
+  color: var(--fg);
+  letter-spacing: -.01em;
+  margin: 0;
+}
+
+/* MDX callout */
+.mdx-callout {
+  border-left: 2px solid var(--border);
+  padding: 12px 16px;
+  border-radius: 0 6px 6px 0;
+  background: var(--bg-subtle);
+}
+.mdx-callout[data-type="insight"] {
+  border-left-color: var(--accent);
+}
+.mdx-callout[data-type="warning"] {
+  border-left-color: var(--amber);
+}
+.mdx-callout p {
+  margin: 0;
+  font-size: 14px !important;
+  line-height: 1.65 !important;
+}
 .exp-empty a { color: var(--fg); }
 
 @media(max-width: 640px) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ export default function Page() {
         <Link href="/experiments" className="exp-teaser-row">
           <div>
             <div className="exp-teaser-name">Experiments</div>
-            <div className="exp-teaser-sub">19 interactive demos — CSS, animation, physics</div>
+            <div className="exp-teaser-sub">18 interactive studies — physics, color, typography, interaction</div>
           </div>
           <span className="exp-teaser-arrow">→</span>
         </Link>

--- a/components/mdx/Callout.tsx
+++ b/components/mdx/Callout.tsx
@@ -1,0 +1,18 @@
+"use client";
+import type { ReactNode } from "react";
+
+type CalloutProps = {
+  children: ReactNode;
+  type?: "note" | "insight" | "warning";
+};
+
+export function Callout({ children, type = "note" }: CalloutProps) {
+  return (
+    <aside
+      className="mdx-callout"
+      data-type={type}
+    >
+      {children}
+    </aside>
+  );
+}

--- a/components/sections/Experiments.tsx
+++ b/components/sections/Experiments.tsx
@@ -8,24 +8,23 @@ import { useCallback, useEffect, useRef, useState } from "react";
  */
 export type ExpId =
   | "var-font"
-  | "bento"
-  | "scroll-progress"
   | "spring-btn"
   | "cursor-trail"
   | "tilt-card"
   | "cmd"
   | "mag"
-  | "cnt"
-  | "stk"
   | "noise-btn"
-  | "scramble"
-  | "abb"
   | "seg-ctrl"
   | "toast"
   | "drag"
   | "checkbox"
   | "dock"
-  | "island";
+  | "island"
+  | "oklch"
+  | "fluid-type"
+  | "flip-list"
+  | "spring-config"
+  | "focus-ring";
 
 export type Exp = {
   id: ExpId;
@@ -37,28 +36,28 @@ export type Exp = {
 
 export const EXPS: Exp[] = [
   {
+    id: "oklch",
+    name: "OKLCH Color Mixer",
+    date: "May 2025",
+    desc: "Gradient interpolation in perceptual OKLCH vs sRGB — the difference is stark.",
+    detail:
+      "sRGB interpolation between two hues cuts through a desaturated grey midpoint. OKLCH interpolates through perceived lightness — L stays constant, so the midpoint is vivid, never muddy. Drag the hue sliders. The top gradient is sRGB. The bottom is OKLCH. The difference defines modern color in CSS.",
+  },
+  {
+    id: "fluid-type",
+    name: "Fluid Typography",
+    date: "Apr 2025",
+    desc: "A type scale that flows between min and max with CSS clamp() — no breakpoints.",
+    detail:
+      "Each step in the scale is defined by a single clamp(): a minimum size, a fluid midpoint tied to viewport width, and a maximum. Drag the viewport slider. The heading, body, and caption respond independently. The formula: clamp(min, min + (max - min) * ((100vw - 320px) / (1200 - 320)), max).",
+  },
+  {
     id: "var-font",
     name: "Variable Font Morph",
     date: "Mar 2025",
     desc: "Font weight and width axes animate on hover, morphing between states.",
     detail:
       "A single word rendered with a variable font. On hover, the weight axis slides from 300 to 800, and the text visibly breathes. The easing curve overshoots slightly before settling, giving it physical weight. Built entirely with font-variation-settings and a CSS transition. Drag the slider to explore the weight axis manually.",
-  },
-  {
-    id: "bento",
-    name: "Bento Grid",
-    date: "Feb 2025",
-    desc: "An asymmetric feature grid where each card has its own personality.",
-    detail:
-      "Five cards in a CSS Grid layout: one large hero card, two medium, two small. Each has a different internal layout. The grid gaps are intentionally uneven. Cards lift with a box-shadow on hover. Resize the window and the grid reflows at defined breakpoints using named grid areas.",
-  },
-  {
-    id: "scroll-progress",
-    name: "Scroll-Linked Progress",
-    date: "Jan 2025",
-    desc: "A reading progress bar driven by scroll position with zero JS in the CSS version.",
-    detail:
-      "A 3px bar at the top of a scrollable container fills as you scroll. The pure-CSS version uses animation-timeline: scroll()  no scroll event listeners, no requestAnimationFrame. The demo uses a JS fallback for cross-browser support.",
   },
   {
     id: "spring-btn",
@@ -101,22 +100,6 @@ export const EXPS: Exp[] = [
       "As the cursor approaches the button, it translates toward the cursor, up to 8px in any direction. The pull is proportional to distance from centre. On mouseleave, it springs back using cubic-bezier(.23,1,.32,1) with a slight overshoot.",
   },
   {
-    id: "cnt",
-    name: "Animated Counter",
-    date: "Jul 2024",
-    desc: "Numbers count up from zero when scrolled into view, driven by easeOutCubic.",
-    detail:
-      "Three stats animate independently with a slight stagger. The easing is easeOutCubic: fast at the start, slowing into the final value. An IntersectionObserver triggers on first entry. A replay button resets and re-runs all three.",
-  },
-  {
-    id: "stk",
-    name: "Image Stack",
-    date: "Jun 2024",
-    desc: "Stacked avatar circles fan out on hover with a spring overshoot.",
-    detail:
-      "Four avatar circles overlapping at rest. On hover they fan out symmetrically: first rotates left, last rotates right. The transition uses cubic-bezier(.34,1.56,.64,1), the spring with perceptible overshoot. On mouseleave they snap back.",
-  },
-  {
     id: "noise-btn",
     name: "Noise Button",
     date: "May 2024",
@@ -125,28 +108,12 @@ export const EXPS: Exp[] = [
       "Two layered pseudo-elements: a fractal noise SVG filter (mix-blend-mode: overlay) adds grain that makes the surface feel physical. On hover, a diagonal gradient animates from right to left, simulating a light sweep. The combination Vercel and Linear use on premium CTAs.",
   },
   {
-    id: "scramble",
-    name: "Text Scramble",
-    date: "Apr 2024",
-    desc: "Characters cycle through random glyphs before resolving, left to right.",
-    detail:
-      "On hover, each character cycles through random alphanumerics at ~30fps. Characters resolve left to right  leftmost locks in first. The effect feels like a terminal decoding a message. The iteration speed is fractional so the decoding isn't perfectly mechanical.",
-  },
-  {
-    id: "abb",
-    name: "Apple Bottom Bar",
-    date: "Mar 2024",
-    desc: "Recreation of the frosted-glass pill from the iPhone 15 marketing page.",
-    detail:
-      "A rounded pill with backdrop-filter: blur(20px), semi-transparent background, and a subtle white border. The blur radius and opacity are calibrated to match Apple's implementation  most copies get the opacity wrong (too high) or the border wrong (too visible).",
-  },
-  {
     id: "seg-ctrl",
     name: "Segmented Control",
     date: "Feb 2024",
     desc: "A pill indicator slides between segments with a spring that slightly overshoots.",
     detail:
-      "Three segments: Design, Code, Ship. A white pill indicator slides under the active segment using cubic-bezier(.34,1.1,.64,1)  just enough overshoot to feel lively. The indicator width morphs to match each button's width.",
+      "Three segments: Design, Code, Ship. A white pill indicator slides under the active segment using cubic-bezier(.34,1.1,.64,1) — just enough overshoot to feel lively. The indicator width morphs to match each button's width.",
   },
   {
     id: "toast",
@@ -154,7 +121,7 @@ export const EXPS: Exp[] = [
     date: "Jan 2026",
     desc: "Stacked notifications that slide in, queue behind each other, and auto-dismiss.",
     detail:
-      "Three types: success, error, info. New toasts land at the front; older ones stack behind at reduced scale and opacity  a visual metaphor for depth. Each auto-dismisses after 3.5 seconds. Click any toast to remove it early. This is the visual language behind Sonner.",
+      "Three types: success, error, info. New toasts land at the front; older ones stack behind at reduced scale and opacity — a visual metaphor for depth. Each auto-dismisses after 3.5 seconds. Click any toast to remove it early. This is the visual language behind Sonner.",
   },
   {
     id: "drag",
@@ -162,7 +129,7 @@ export const EXPS: Exp[] = [
     date: "Dec 2025",
     desc: "A card that tracks pointer drag and dismisses when thrown far enough.",
     detail:
-      "Pointer capture keeps tracking even if the cursor leaves the element. On release, velocity is measured  a fast flick dismisses even if the distance was short. A slow drag needs to exceed 80px. Spring return on abandon. This is the interaction model of every mobile bottom sheet.",
+      "Pointer capture keeps tracking even if the cursor leaves the element. On release, velocity is measured — a fast flick dismisses even if the distance was short. A slow drag needs to exceed 80px. Spring return on abandon. This is the interaction model of every mobile bottom sheet.",
   },
   {
     id: "checkbox",
@@ -178,7 +145,7 @@ export const EXPS: Exp[] = [
     date: "Oct 2025",
     desc: "Icons magnify as the cursor approaches, with Gaussian distance falloff.",
     detail:
-      "Scale is computed as 1 + (maxScale  1)  e^(dist / ). The Gaussian falloff means adjacent icons grow proportionally  the icon under the cursor peaks at 1.8, its neighbours at ~1.4.  controls the spread width. On mouseleave, everything springs back with a gentle overshoot.",
+      "Scale is computed as 1 + (maxScale − 1) × e^(−dist² / σ²). The Gaussian falloff means adjacent icons grow proportionally — the icon under the cursor peaks at 1.8, its neighbours at ~1.4. σ controls the spread width. On mouseleave, everything springs back with a gentle overshoot.",
   },
   {
     id: "island",
@@ -186,7 +153,31 @@ export const EXPS: Exp[] = [
     date: "Sep 2025",
     desc: "Apple's Dynamic Island with five Live Activity states.",
     detail:
-      "The pill morphs between states using a single div  no clipping, no hidden layers. Width and height animate together with a spring that slightly overshoots. Content fades in 150ms after the shape starts moving, so text never rides a distorting container. Five states: ring, alarm, download, navigation, message.",
+      "The pill morphs between states using a single div — no clipping, no hidden layers. Width and height animate together with a spring that slightly overshoots. Content fades in 150ms after the shape starts moving, so text never rides a distorting container. Five states: ring, alarm, download, navigation, message.",
+  },
+  {
+    id: "spring-config",
+    name: "Spring Configurator",
+    date: "Aug 2025",
+    desc: "Tune stiffness, damping, and mass — watch the spring curve respond in real time.",
+    detail:
+      "A ball animates on a spring defined by three parameters. Stiffness sets how fast it pulls toward rest. Damping controls how quickly oscillation dies. Mass slows everything proportionally. The canvas plots the position curve alongside the demo. These are the same numbers driving every animation on this site.",
+  },
+  {
+    id: "flip-list",
+    name: "FLIP Animation",
+    date: "Jul 2025",
+    desc: "List items animate to new positions using the FLIP technique — no layout thrash.",
+    detail:
+      "FLIP: record First positions, shuffle items to get Last positions, Invert by applying a CSS transform that puts each element back in its First position, then Play by removing the transform. The browser animates from the inverted start to zero transform. Items appear to glide, not teleport.",
+  },
+  {
+    id: "focus-ring",
+    name: "Focus Ring System",
+    date: "Jun 2025",
+    desc: "Custom focus indicators that feel designed — not browser defaults, not invisible.",
+    detail:
+      "Tab through four element types: button, input, link, card. Each gets a focus ring tuned to its shape — pill gets a pill ring, square gets a square ring. The ring is drawn with outline and offset, never box-shadow, so it composites correctly. The color adapts to light and dark mode via CSS custom properties.",
   },
 ];
 
@@ -243,182 +234,6 @@ function VarFontDemo() {
         >
           wght: {weight}
         </span>
-      </div>
-    </div>
-  );
-}
-
-/*  Bento Grid  */
-function BentoDemo() {
-  const card = (style?: React.CSSProperties) => ({
-    padding: "16px",
-    border: "1px solid var(--border)",
-    borderRadius: "8px",
-    background: "var(--bg-subtle)",
-    transition: "box-shadow 140ms ease, transform 140ms ease",
-    ...style,
-  });
-  const lift = (e: React.MouseEvent<HTMLDivElement>) => {
-    (e.currentTarget as HTMLElement).style.cssText +=
-      ";box-shadow:var(--shadow-md);transform:translateY(-2px)";
-  };
-  const drop = (e: React.MouseEvent<HTMLDivElement>) => {
-    (e.currentTarget as HTMLElement).style.boxShadow = "";
-    (e.currentTarget as HTMLElement).style.transform = "";
-  };
-
-  return (
-    <div className="exp-demo" style={{ padding: "16px" }}>
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr",
-          gap: "8px",
-          width: "100%",
-          maxWidth: "280px",
-        }}
-      >
-        <div
-          style={{ ...card(), gridColumn: "span 2" }}
-          onMouseEnter={lift}
-          onMouseLeave={drop}
-        >
-          <div
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "36px",
-              fontWeight: 400,
-              color: "var(--fg)",
-              lineHeight: 1,
-            }}
-          >
-            3
-          </div>
-          <div
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "14px",
-              color: "var(--fg-subtle)",
-              marginTop: "4px",
-            }}
-          >
-            companies in production
-          </div>
-        </div>
-        <div style={card()} onMouseEnter={lift} onMouseLeave={drop}>
-          <div
-            style={{
-              fontSize: "14px",
-              fontWeight: 400,
-              color: "var(--fg)",
-              marginBottom: "6px",
-            }}
-          >
-            Huchu
-          </div>
-          <span
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "14px",
-              padding: "1px 5px",
-              borderRadius: "2px",
-              color: "var(--green)",
-              background: "var(--green-bg)",
-            }}
-          >
-            production
-          </span>
-        </div>
-        <div style={card()} onMouseEnter={lift} onMouseLeave={drop}>
-          <div
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "14px",
-              color: "var(--fg-muted)",
-              lineHeight: 1.6,
-            }}
-          >
-            &ldquo;The best way to learn a system is to build it
-            yourself.&rdquo;
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/*  Scroll Progress  */
-function ScrollProgressDemo() {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [pct, setPct] = useState(0);
-
-  const onScroll = () => {
-    const el = containerRef.current;
-    if (!el) return;
-    const max = el.scrollHeight - el.clientHeight;
-    setPct(max > 0 ? (el.scrollTop / max) * 100 : 0);
-  };
-
-  const paragraphs = [
-    "Scroll down to see the progress bar fill. The CSS-only version uses animation-timeline: scroll()  no event listeners needed.",
-    "Every word counts. Specific, not impressive. The bar at the top tracks exactly how far you've read.",
-    "Built to understand every layer of what we ship. Deployment, database, observability  the parts most engineers leave to someone else.",
-    "Three companies currently run software built from scratch. The stakes are real. The code runs in production.",
-    "The best way to learn a system is to build it yourself. Then ship it. Then maintain it.",
-    "I grew up in Zimbabwe writing code for fun. Fifteen years later the fun hasn't stopped.",
-  ];
-
-  return (
-    <div
-      ref={containerRef}
-      className="exp-demo"
-      style={{
-        padding: 0,
-        overflowY: "auto",
-        flexDirection: "column",
-        alignItems: "stretch",
-      }}
-      onScroll={onScroll}
-    >
-      <div
-        style={{
-          position: "sticky",
-          top: 0,
-          height: "3px",
-          background: "var(--border)",
-          zIndex: 10,
-          flexShrink: 0,
-        }}
-      >
-        <div
-          style={{
-            height: "100%",
-            background: "var(--accent)",
-            width: `${pct}%`,
-            transition: "width 0ms",
-          }}
-        />
-      </div>
-      <div style={{ padding: "20px", flexShrink: 0 }}>
-        <span
-          className="exp-demo-label"
-          style={{ position: "static", marginBottom: "16px", display: "block" }}
-        >
-          scroll progress
-        </span>
-        {paragraphs.map((p, i) => (
-          <p
-            key={i}
-            style={{
-              fontSize: "14px",
-              color: "var(--fg-muted)",
-              lineHeight: 1.8,
-              marginBottom: "14px",
-            }}
-          >
-            {p}
-          </p>
-        ))}
       </div>
     </div>
   );
@@ -791,108 +606,6 @@ function MagDemo() {
   );
 }
 
-/*  Animated Counter  */
-function useCounter(target: number, dur: number, running: boolean) {
-  const [v, setV] = useState(0);
-  useEffect(() => {
-    if (!running) {
-      setV(0);
-      return;
-    }
-    const t0 = performance.now();
-    let raf: number;
-    const tick = (now: number) => {
-      const p = Math.min((now - t0) / dur, 1);
-      setV(Math.round((1 - Math.pow(1 - p, 3)) * target));
-      if (p < 1) raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, [running, target, dur]);
-  return v;
-}
-
-function CntDemo() {
-  const [running, setRunning] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const replay = useCallback(() => {
-    setRunning(false);
-    setTimeout(() => setRunning(true), 50);
-  }, []);
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const obs = new IntersectionObserver(
-      ([e]) => {
-        if (e.isIntersecting) setRunning(true);
-      },
-      { threshold: 0.5 },
-    );
-    obs.observe(el);
-    return () => obs.disconnect();
-  }, []);
-  const a = useCounter(3, 1000, running);
-  const b = useCounter(10, 1600, running);
-  const c = useCounter(6, 1300, running);
-
-  return (
-    <div
-      ref={ref}
-      className="exp-demo"
-      style={{ flexDirection: "column", gap: "24px" }}
-    >
-      <span className="exp-demo-label">animated counter</span>
-      <div className="d-counters">
-        {[
-          { v: a, l: "companies" },
-          { v: b, l: "open-source stars" },
-          { v: c, l: "yrs building" },
-        ].map(({ v, l }) => (
-          <div key={l} className="d-counter">
-            <div className="d-counter-val">{v}</div>
-            <div className="d-counter-lbl">{l}</div>
-          </div>
-        ))}
-      </div>
-      <button className="d-counter-replay" onClick={replay}>
-        Replay
-      </button>
-    </div>
-  );
-}
-
-/*  Image Stack  */
-function StkDemo() {
-  const [spread, setSpread] = useState(false);
-  const people = ["TC", "FM", "RN", "AK"];
-
-  return (
-    <div className="exp-demo" style={{ flexDirection: "column", gap: "16px" }}>
-      <span className="exp-demo-label">image stack</span>
-      <div
-        className={`d-stack${spread ? " spread" : ""}`}
-        onClick={() => setSpread((v) => !v)}
-      >
-        {people.map((person, i) => (
-          <div key={person} className="d-stack-img" data-tone={i}>
-            {person}
-          </div>
-        ))}
-      </div>
-      <p
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: "14px",
-          color: "var(--fg-subtle)",
-          marginTop: "12px",
-        }}
-      >
-        click to {spread ? "collapse" : "spread"}
-      </p>
-    </div>
-  );
-}
-
 /*  Noise Button  */
 function NoiseBtnDemo() {
   return (
@@ -919,90 +632,6 @@ function NoiseBtnDemo() {
         <div className="d-noise-btn-shine" />
         <span style={{ position: "relative" }}>Hover me</span>
       </button>
-    </div>
-  );
-}
-
-/*  Text Scramble  */
-function ScrambleDemo() {
-  const TARGET = "CORELITH";
-  const CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  const [display, setDisplay] = useState(TARGET);
-  const rafRef = useRef<number>();
-  const t0 = useRef(0);
-  const LOCK_DELAY = 65;
-  const SCRAMBLE_DUR = 320;
-
-  const scramble = useCallback(() => {
-    if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    t0.current = performance.now();
-    const tick = (now: number) => {
-      const elapsed = now - t0.current;
-      let allDone = true;
-      const result = TARGET.split("").map((ch, i) => {
-        if (elapsed >= i * LOCK_DELAY + SCRAMBLE_DUR) return ch;
-        allDone = false;
-        return CHARS[Math.floor(Math.random() * CHARS.length)];
-      });
-      setDisplay(result.join(""));
-      if (!allDone) rafRef.current = requestAnimationFrame(tick);
-      else setDisplay(TARGET);
-    };
-    rafRef.current = requestAnimationFrame(tick);
-  }, []);
-
-  useEffect(
-    () => () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    },
-    [],
-  );
-
-  return (
-    <div className="exp-demo" style={{ flexDirection: "column", gap: "24px" }}>
-      <span className="exp-demo-label">text scramble</span>
-      <div
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: "32px",
-          fontWeight: 400,
-          color: "var(--fg)",
-          letterSpacing: ".04em",
-          cursor: "default",
-          userSelect: "none",
-        }}
-        onMouseEnter={scramble}
-      >
-        {display}
-      </div>
-      <button
-        onClick={scramble}
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: "14px",
-          color: "var(--fg-subtle)",
-          background: "none",
-          border: "1px solid var(--border)",
-          borderRadius: "4px",
-          padding: "4px 10px",
-          cursor: "pointer",
-        }}
-      >
-        Scramble again
-      </button>
-    </div>
-  );
-}
-
-/*  Apple Bottom Bar  */
-function AbbDemo() {
-  return (
-    <div className="exp-demo">
-      <span className="exp-demo-label">apple bottom bar</span>
-      <div className="d-abb">
-        <span className="d-abb-text">Learn more</span>
-        <div className="d-abb-icon" aria-hidden="true" />
-      </div>
     </div>
   );
 }
@@ -1407,6 +1036,442 @@ function DockDemo() {
     </div>
   );
 }
+/*  OKLCH Color Mixer  */
+function OklchDemo() {
+  const [hue1, setHue1] = useState(260);
+  const [hue2, setHue2] = useState(160);
+
+  const oklchGradient = (h1: number, h2: number) => {
+    const steps = 7;
+    const stops = Array.from({ length: steps }, (_, i) => {
+      const t = i / (steps - 1);
+      const h = h1 + (h2 - h1) * t;
+      const hRad = (h * Math.PI) / 180;
+      const L = 0.65;
+      const C = 0.18;
+      const a = C * Math.cos(hRad);
+      const b = C * Math.sin(hRad);
+      const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+      const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+      const s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+      const lc = l_ * l_ * l_;
+      const mc = m_ * m_ * m_;
+      const sc = s_ * s_ * s_;
+      let r = +4.0767416621 * lc - 3.3077115913 * mc + 0.2309699292 * sc;
+      let g = -1.2684380046 * lc + 2.6097574011 * mc - 0.3413193965 * sc;
+      let bv = -0.0041960863 * lc - 0.7034186147 * mc + 1.7076147010 * sc;
+      const toSrgb = (x: number) => {
+        const v = Math.max(0, Math.min(1, x));
+        return Math.round((v <= 0.0031308 ? 12.92 * v : 1.055 * Math.pow(v, 1 / 2.4) - 0.055) * 255);
+      };
+      return `rgb(${toSrgb(r)},${toSrgb(g)},${toSrgb(bv)}) ${(t * 100).toFixed(0)}%`;
+    });
+    return `linear-gradient(90deg, ${stops.join(", ")})`;
+  };
+
+  return (
+    <div className="exp-demo" style={{ flexDirection: "column", gap: "20px", padding: "24px" }}>
+      <span className="exp-demo-label">oklch color mixer</span>
+      <div style={{ display: "flex", flexDirection: "column", gap: "10px", width: "100%" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "12px", color: "var(--fg-subtle)" }}>
+            sRGB — hue {hue1}° → {hue2}°
+          </span>
+          <div
+            style={{
+              height: "36px",
+              borderRadius: "6px",
+              background: `linear-gradient(90deg, hsl(${hue1},70%,55%), hsl(${hue2},70%,55%))`,
+              border: "1px solid var(--border)",
+            }}
+          />
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "12px", color: "var(--fg-subtle)" }}>
+            OKLCH — perceptual L=0.65 C=0.18
+          </span>
+          <div
+            style={{
+              height: "36px",
+              borderRadius: "6px",
+              background: oklchGradient(hue1, hue2),
+              border: "1px solid var(--border)",
+            }}
+          />
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: "16px", width: "100%" }}>
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "4px" }}>
+          <label style={{ fontFamily: "var(--font-mono)", fontSize: "12px", color: "var(--fg-subtle)" }}>
+            Hue A: {hue1}°
+          </label>
+          <input type="range" min="0" max="360" value={hue1} onChange={(e) => setHue1(Number(e.target.value))} style={{ width: "100%", accentColor: "var(--accent)" }} />
+        </div>
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "4px" }}>
+          <label style={{ fontFamily: "var(--font-mono)", fontSize: "12px", color: "var(--fg-subtle)" }}>
+            Hue B: {hue2}°
+          </label>
+          <input type="range" min="0" max="360" value={hue2} onChange={(e) => setHue2(Number(e.target.value))} style={{ width: "100%", accentColor: "var(--accent)" }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/*  Fluid Typography  */
+function FluidTypeDemo() {
+  const [vw, setVw] = useState(768);
+  const MIN_VW = 320;
+  const MAX_VW = 1200;
+
+  const fluid = (minPx: number, maxPx: number) => {
+    const slope = (maxPx - minPx) / (MAX_VW - MIN_VW);
+    const intercept = minPx - slope * MIN_VW;
+    const preferred = slope * vw + intercept;
+    return Math.min(maxPx, Math.max(minPx, preferred));
+  };
+
+  const headingSize = fluid(28, 52);
+  const bodySize = fluid(15, 18);
+  const captionSize = fluid(12, 14);
+  const pct = ((vw - MIN_VW) / (MAX_VW - MIN_VW)) * 100;
+
+  return (
+    <div className="exp-demo" style={{ flexDirection: "column", gap: "20px", padding: "24px", alignItems: "stretch" }}>
+      <span className="exp-demo-label">fluid typography</span>
+      <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+        <div style={{ fontSize: headingSize, fontWeight: 700, color: "var(--fg)", lineHeight: 1.1, letterSpacing: "-.02em", transition: "font-size 60ms ease" }}>
+          Design systems
+        </div>
+        <div style={{ fontSize: bodySize, color: "var(--fg-muted)", lineHeight: 1.6, transition: "font-size 60ms ease" }}>
+          Typography that scales continuously, not discretely.
+        </div>
+        <div style={{ fontSize: captionSize, fontFamily: "var(--font-mono)", color: "var(--fg-subtle)", transition: "font-size 60ms ease" }}>
+          {headingSize.toFixed(1)}px heading · {bodySize.toFixed(1)}px body · {captionSize.toFixed(1)}px caption
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "12px", color: "var(--fg-subtle)" }}>Viewport: {vw}px</span>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "12px", color: "var(--fg-subtle)" }}>{pct.toFixed(0)}% of range</span>
+        </div>
+        <input type="range" min={MIN_VW} max={MAX_VW} value={vw} onChange={(e) => setVw(Number(e.target.value))} style={{ width: "100%", accentColor: "var(--accent)" }} />
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--fg-subtle)" }}>{MIN_VW}px</span>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--fg-subtle)" }}>{MAX_VW}px</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/*  Spring Configurator  */
+function SpringConfigDemo() {
+  const [stiffness, setStiffness] = useState(200);
+  const [damping, setDamping] = useState(18);
+  const [mass, setMass] = useState(1);
+  const [running, setRunning] = useState(false);
+  const [ballY, setBallY] = useState(0);
+  const [curve, setCurve] = useState<number[]>([]);
+  const rafRef = useRef<number>();
+
+  const run = useCallback(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    const TARGET = 80;
+    let pos = 0;
+    let vel = 0;
+    const dt = 1 / 60;
+    const pts: number[] = [];
+    setRunning(true);
+    setBallY(0);
+
+    const tick = () => {
+      const force = -stiffness * (pos - TARGET) - damping * vel;
+      const acc = force / mass;
+      vel += acc * dt;
+      pos += vel * dt;
+      pts.push(pos);
+      setBallY(pos);
+      if (pts.length < 120) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        setCurve([...pts]);
+        setRunning(false);
+      }
+    };
+    setCurve([]);
+    rafRef.current = requestAnimationFrame(tick);
+  }, [stiffness, damping, mass]);
+
+  useEffect(() => { run(); }, [run]);
+  useEffect(() => () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); }, []);
+
+  const W = 220;
+  const H = 80;
+  const TARGET_VAL = 80;
+  const pts = curve.length > 0 ? curve : [];
+  const maxY = Math.max(TARGET_VAL, ...pts);
+  const pathD = pts
+    .map((y, i) => {
+      const x = (i / (pts.length - 1 || 1)) * W;
+      const py = H - (y / maxY) * (H - 4);
+      return `${i === 0 ? "M" : "L"} ${x.toFixed(1)} ${py.toFixed(1)}`;
+    })
+    .join(" ");
+
+  return (
+    <div className="exp-demo" style={{ flexDirection: "column", gap: "16px", padding: "20px" }}>
+      <span className="exp-demo-label">spring configurator</span>
+      <div style={{ display: "flex", gap: "20px", alignItems: "flex-end" }}>
+        <div style={{ position: "relative", width: "32px", height: "100px", background: "var(--bg-subtle)", borderRadius: "6px", border: "1px solid var(--border)", overflow: "hidden" }}>
+          <div
+            style={{
+              position: "absolute",
+              bottom: `calc(${((ballY / 100) * 60)}px)`,
+              left: "4px",
+              right: "4px",
+              height: "24px",
+              background: "var(--accent)",
+              borderRadius: "4px",
+              transition: running ? "none" : undefined,
+            }}
+          />
+        </div>
+        <div style={{ flex: 1 }}>
+          <svg width={W} height={H} style={{ display: "block" }}>
+            <line x1="0" y1={H - (TARGET_VAL / maxY) * (H - 4)} x2={W} y2={H - (TARGET_VAL / maxY) * (H - 4)} stroke="var(--border)" strokeWidth="1" strokeDasharray="3,3" />
+            {pathD && <path d={pathD} fill="none" stroke="var(--accent)" strokeWidth="1.5" />}
+          </svg>
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+        {([["Stiffness", stiffness, setStiffness, 20, 600] as const,
+           ["Damping", damping, setDamping, 1, 60] as const,
+           ["Mass", mass, setMass, 0.1, 4] as const] as const).map(([label, val, setter, min, max]) => (
+          <div key={label} style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--fg-subtle)", width: "70px", flexShrink: 0 }}>{label}: {typeof val === "number" && val < 10 ? val.toFixed(1) : val}</span>
+            <input
+              type="range"
+              min={min}
+              max={max}
+              step={label === "Mass" ? 0.1 : 1}
+              value={val}
+              onChange={(e) => setter(Number(e.target.value) as never)}
+              style={{ flex: 1, accentColor: "var(--accent)" }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/*  FLIP List Animation  */
+function FlipListDemo() {
+  const ITEMS = ["Render", "Layout", "Paint", "Composite"];
+  const [order, setOrder] = useState(ITEMS);
+  const [animating, setAnimating] = useState(false);
+  const refsMap = useRef<Map<string, HTMLDivElement>>(new Map());
+  const prevPositions = useRef<Map<string, DOMRect>>(new Map());
+
+  const shuffle = useCallback(() => {
+    if (animating) return;
+    const els = refsMap.current;
+    prevPositions.current.clear();
+    els.forEach((el, key) => {
+      prevPositions.current.set(key, el.getBoundingClientRect());
+    });
+    setOrder((prev) => {
+      const arr = [...prev];
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      return arr;
+    });
+  }, [animating]);
+
+  useEffect(() => {
+    const els = refsMap.current;
+    const prev = prevPositions.current;
+    if (prev.size === 0) return;
+    const toPlay: { el: HTMLDivElement; dx: number; dy: number }[] = [];
+    els.forEach((el, key) => {
+      const old = prev.get(key);
+      if (!old) return;
+      const cur = el.getBoundingClientRect();
+      const dx = old.left - cur.left;
+      const dy = old.top - cur.top;
+      if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
+        toPlay.push({ el, dx, dy });
+      }
+    });
+    if (toPlay.length === 0) return;
+    setAnimating(true);
+    toPlay.forEach(({ el, dx, dy }) => {
+      el.style.transform = `translate(${dx}px,${dy}px)`;
+      el.style.transition = "none";
+    });
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        toPlay.forEach(({ el }) => {
+          el.style.transform = "";
+          el.style.transition = "transform 380ms cubic-bezier(.34,1.2,.64,1)";
+        });
+        setTimeout(() => setAnimating(false), 400);
+      });
+    });
+  }, [order]);
+
+  return (
+    <div className="exp-demo" style={{ flexDirection: "column", gap: "16px", padding: "20px" }}>
+      <span className="exp-demo-label">flip list</span>
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px", width: "100%" }}>
+        {order.map((item) => (
+          <div
+            key={item}
+            ref={(el) => {
+              if (el) refsMap.current.set(item, el);
+              else refsMap.current.delete(item);
+            }}
+            style={{
+              padding: "10px 14px",
+              border: "1px solid var(--border)",
+              borderRadius: "6px",
+              background: "var(--bg-subtle)",
+              fontSize: "14px",
+              color: "var(--fg)",
+              fontFamily: "var(--font-mono)",
+              userSelect: "none",
+            }}
+          >
+            {item}
+          </div>
+        ))}
+      </div>
+      <button
+        onClick={shuffle}
+        style={{
+          padding: "8px 18px",
+          background: "var(--bg-subtle)",
+          border: "1px solid var(--border)",
+          borderRadius: "6px",
+          cursor: "pointer",
+          fontFamily: "var(--font-mono)",
+          fontSize: "13px",
+          color: "var(--fg-muted)",
+          alignSelf: "center",
+        }}
+      >
+        Shuffle
+      </button>
+    </div>
+  );
+}
+
+/*  Focus Ring System  */
+function FocusRingDemo() {
+  const [focused, setFocused] = useState<string | null>(null);
+
+  const ringStyle = (id: string, shape: "pill" | "rect" | "underline" = "rect"): React.CSSProperties => {
+    const isFocused = focused === id;
+    if (!isFocused) return {};
+    return {
+      outline: shape === "underline" ? "none" : "2px solid var(--accent)",
+      outlineOffset: shape === "pill" ? "3px" : "2px",
+      borderBottom: shape === "underline" ? "2px solid var(--accent)" : undefined,
+      boxShadow: shape === "underline" ? "none" : "0 0 0 4px color-mix(in oklch, var(--accent) 18%, transparent)",
+    };
+  };
+
+  const focusProps = (id: string) => ({
+    onFocus: () => setFocused(id),
+    onBlur: () => setFocused(null),
+    style: { outline: "none" },
+  });
+
+  return (
+    <div
+      className="exp-demo"
+      style={{ flexDirection: "column", gap: "20px", padding: "24px", alignItems: "stretch" }}
+    >
+      <span className="exp-demo-label">focus ring system — tab through</span>
+      <div style={{ display: "flex", flexDirection: "column", gap: "14px" }}>
+        <button
+          {...focusProps("btn")}
+          style={{
+            padding: "10px 20px",
+            background: "var(--accent)",
+            color: "#fff",
+            border: "none",
+            borderRadius: "100px",
+            cursor: "pointer",
+            fontFamily: "var(--font-sans)",
+            fontSize: "14px",
+            alignSelf: "flex-start",
+            transition: "outline-offset 100ms ease, box-shadow 100ms ease",
+            ...ringStyle("btn", "pill"),
+          }}
+        >
+          Primary action
+        </button>
+        <input
+          {...focusProps("input")}
+          defaultValue="Type something"
+          style={{
+            padding: "9px 12px",
+            background: "var(--bg-subtle)",
+            color: "var(--fg)",
+            border: "1px solid var(--border)",
+            borderRadius: "6px",
+            fontFamily: "var(--font-sans)",
+            fontSize: "14px",
+            transition: "outline-offset 100ms ease, box-shadow 100ms ease",
+            ...ringStyle("input"),
+          }}
+        />
+        <a
+          href="#"
+          {...focusProps("link")}
+          onClick={(e) => e.preventDefault()}
+          style={{
+            fontFamily: "var(--font-sans)",
+            fontSize: "14px",
+            color: "var(--accent)",
+            textDecoration: "underline",
+            alignSelf: "flex-start",
+            paddingBottom: "1px",
+            transition: "outline-offset 100ms ease, box-shadow 100ms ease",
+            ...ringStyle("link", "underline"),
+          }}
+        >
+          Inline link
+        </a>
+        <div
+          {...focusProps("card")}
+          tabIndex={0}
+          style={{
+            padding: "12px 14px",
+            border: "1px solid var(--border)",
+            borderRadius: "8px",
+            background: "var(--bg-card)",
+            cursor: "pointer",
+            fontSize: "14px",
+            color: "var(--fg-muted)",
+            transition: "outline-offset 100ms ease, box-shadow 100ms ease",
+            ...ringStyle("card"),
+          }}
+        >
+          Focusable card
+        </div>
+      </div>
+      <p style={{ fontFamily: "var(--font-mono)", fontSize: "12px", color: "var(--fg-subtle)", margin: 0 }}>
+        {focused ? `focused: ${focused}` : "click an element or press Tab"}
+      </p>
+    </div>
+  );
+}
+
 /*  Dynamic Island  */
 type IslandState = "idle" | "ring" | "alarm" | "download" | "nav" | "message";
 const ISLAND_DIMS: Record<IslandState, { w: number; h: number }> = {
@@ -1653,6 +1718,35 @@ function IslandDemo() {
    CODE SNIPPETS
  */
 const CODE: Record<ExpId, string> = {
+  oklch: `<span class="cm">/* OKLCH interpolation — perceptual L stays constant */</span>
+<span class="cm">/* sRGB: hsl(260,70%,55%) → hsl(160,70%,55%) — greys out in middle */</span>
+background: linear-gradient(90deg,
+  hsl(<span class="num">260</span>,<span class="num">70%</span>,<span class="num">55%</span>),
+  hsl(<span class="num">160</span>,<span class="num">70%</span>,<span class="num">55%</span>));
+
+<span class="cm">/* OKLCH: manual steps at L=0.65, C=0.18 */</span>
+background: linear-gradient(90deg,
+  oklch(<span class="num">0.65</span> <span class="num">0.18</span> <span class="num">260</span>),
+  oklch(<span class="num">0.65</span> <span class="num">0.18</span> <span class="num">200</span>),
+  oklch(<span class="num">0.65</span> <span class="num">0.18</span> <span class="num">160</span>));
+
+<span class="cm">/* Native in modern CSS — no JS needed */</span>`,
+
+  "fluid-type": `<span class="cm">/* clamp(min, preferred, max) */</span>
+.<span class="fn">heading</span> {
+  font-size: <span class="fn">clamp</span>(
+    <span class="num">1.75rem</span>,
+    <span class="cm">/* slope × 100vw + intercept */</span>
+    calc(<span class="num">1.75rem</span> + <span class="num">1.5</span> *
+      ((100vw - <span class="num">20rem</span>) / (<span class="num">75</span> - <span class="num">20</span>))),
+    <span class="num">3.25rem</span>
+  );
+}
+
+<span class="cm">/* Same formula, different scale steps */</span>
+.<span class="fn">body</span>    { font-size: <span class="fn">clamp</span>(<span class="num">0.9375rem</span>, calc(...), <span class="num">1.125rem</span>); }
+.<span class="fn">caption</span> { font-size: <span class="fn">clamp</span>(<span class="num">0.75rem</span>,   calc(...), <span class="num">0.875rem</span>); }`,
+
   "var-font": `<span class="cm">/* Animate weight axis on hover */</span>
 .<span class="fn">word</span> {
   <span class="prop">font-variation-settings</span>: <span class="str">'wght'</span> <span class="kw">var</span>(--weight, <span class="num">300</span>);
@@ -1666,42 +1760,6 @@ const CODE: Record<ExpId, string> = {
 <span class="cm">/* Or drive with JS for a range slider */</span>
 <span class="kw">const</span> [weight, setWeight] = <span class="fn">useState</span>(<span class="num">300</span>)
 style={{ fontVariationSettings: \`<span class="str">'wght' \${weight}</span>\` }}`,
-
-  bento: `.<span class="fn">grid</span> {
-  <span class="prop">display</span>: grid;
-  <span class="prop">grid-template-columns</span>: <span class="num">1fr 1fr</span>;
-  <span class="prop">grid-template-areas</span>:
-    <span class="str">"hero hero"</span>
-    <span class="str">"stat  quote"</span>
-    <span class="str">"tags  location"</span>;
-  <span class="prop">gap</span>: <span class="num">8px</span>;
-}
-.<span class="fn">hero</span> { <span class="prop">grid-area</span>: hero }
-
-.<span class="fn">card</span>:hover {
-  <span class="prop">box-shadow</span>: var(--shadow-md);
-  <span class="prop">transform</span>: translateY(-<span class="num">2px</span>);
-  <span class="prop">transition</span>: transform <span class="num">140ms</span> ease,
-              box-shadow <span class="num">140ms</span> ease;
-}`,
-
-  "scroll-progress": `<span class="cm">/* CSS-only  Scroll Timeline API */</span>
-.<span class="fn">progress</span> {
-  <span class="prop">animation</span>: fill linear;
-  <span class="prop">animation-timeline</span>: <span class="fn">scroll</span>(nearest);
-  <span class="prop">transform-origin</span>: left center;
-}
-@keyframes <span class="fn">fill</span> {
-  <span class="kw">from</span> { transform: scaleX(<span class="num">0</span>) }
-  <span class="kw">to</span>   { transform: scaleX(<span class="num">1</span>) }
-}
-
-<span class="cm">/* JS fallback for Safari */</span>
-container.<span class="fn">addEventListener</span>(<span class="str">'scroll'</span>, () => {
-  <span class="kw">const</span> p = el.scrollTop /
-    (el.scrollHeight - el.clientHeight)
-  bar.style.width = \`\${p * <span class="num">100</span>}%\`
-})`,
 
   "spring-btn": `<span class="cm">/* Squash on press, spring on release */</span>
 .<span class="fn">btn</span>:active {
@@ -1778,32 +1836,6 @@ style={{
     : <span class="str">'transform 400ms cubic-bezier(.23,1,.32,1)'</span>
 }}`,
 
-  cnt: `<span class="cm">// easeOutCubic counter via rAF</span>
-<span class="kw">const</span> t0 = performance.<span class="fn">now</span>()
-<span class="kw">const</span> <span class="fn">tick</span> = (now: <span class="kw">number</span>) => {
-  <span class="kw">const</span> p = Math.<span class="fn">min</span>((now - t0) / dur, <span class="num">1</span>)
-  <span class="fn">setVal</span>(Math.<span class="fn">round</span>(
-    (<span class="num">1</span> - (<span class="num">1</span> - p) ** <span class="num">3</span>) * target
-  ))
-  <span class="kw">if</span> (p < <span class="num">1</span>) <span class="fn">requestAnimationFrame</span>(tick)
-}
-<span class="fn">requestAnimationFrame</span>(tick)`,
-
-  stk: `<span class="cm">/* CSS drives all transforms */</span>
-.<span class="fn">d-stack-img</span> {
-  <span class="prop">transition</span>: transform <span class="num">320ms</span>
-    cubic-bezier(.<span class="num">34</span>, <span class="num">1.56</span>, .<span class="num">64</span>, <span class="num">1</span>);
-}
-.<span class="fn">spread</span> :nth-child(<span class="num">1</span>) {
-  transform: translateX(-<span class="num">24px</span>) rotate(-<span class="num">8deg</span>);
-}
-.<span class="fn">spread</span> :nth-child(<span class="num">2</span>) {
-  transform: translateX(-<span class="num">8px</span>) rotate(-<span class="num">3deg</span>);
-}
-
-<span class="cm">// React toggles the class</span>
-<span class="kw">const</span> [spread, setSpread] = <span class="fn">useState</span>(<span class="kw">false</span>)`,
-
   "noise-btn": `<span class="cm">/* Grain layer via SVG filter */</span>
 &lt;filter id=<span class="str">"noise"</span>&gt;
   &lt;feTurbulence
@@ -1823,33 +1855,6 @@ style={{
 }
 .<span class="fn">btn</span>:hover .<span class="fn">shine</span> {
   background-position: -<span class="num">100%</span>;
-}`,
-
-  scramble: `<span class="cm">// Characters resolve left-to-right via rAF</span>
-<span class="kw">const</span> CHARS = <span class="str">"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"</span>
-<span class="kw">const</span> LOCK_DELAY = <span class="num">65</span> <span class="cm">// ms per character</span>
-
-<span class="kw">const</span> <span class="fn">tick</span> = (now: <span class="kw">number</span>) => {
-  <span class="kw">const</span> elapsed = now - t0.current
-  <span class="kw">const</span> result = TARGET.<span class="fn">split</span>(<span class="str">""</span>).<span class="fn">map</span>((ch, i) => {
-    <span class="kw">if</span> (elapsed >= i * LOCK_DELAY + <span class="num">320</span>)
-      <span class="kw">return</span> ch <span class="cm">// locked</span>
-    <span class="kw">return</span> CHARS[Math.<span class="fn">floor</span>(Math.<span class="fn">random</span>() * CHARS.length)]
-  })
-  <span class="fn">setDisplay</span>(result.<span class="fn">join</span>(<span class="str">""</span>))
-}`,
-
-  abb: `<span class="cm">/* Glass morphism */</span>
-.<span class="fn">pill</span> {
-  background: rgba(<span class="num">255</span>,<span class="num">255</span>,<span class="num">255</span>, .<span class="num">75</span>);
-  backdrop-filter: blur(<span class="num">20px</span>);
-  -webkit-backdrop-filter: blur(<span class="num">20px</span>);
-  border: <span class="num">1px</span> solid rgba(<span class="num">255</span>,<span class="num">255</span>,<span class="num">255</span>, .<span class="num">5</span>);
-  border-radius: <span class="num">100px</span>;
-}
-[data-theme=<span class="str">"dark"</span>] .<span class="fn">pill</span> {
-  background: rgba(<span class="num">30</span>,<span class="num">30</span>,<span class="num">28</span>, .<span class="num">8</span>);
-  border-color: rgba(<span class="num">255</span>,<span class="num">255</span>,<span class="num">255</span>, .<span class="num">08</span>);
 }`,
 
   "seg-ctrl": `<span class="cm">// Pill indicator tracks active button</span>
@@ -1939,50 +1944,101 @@ style={{
 <span class="cm">// Content fades in 160ms after morph starts</span>
 opacity: vis && state !== <span class="str">'idle'</span> ? <span class="num">1</span> : <span class="num">0</span>,
 transition: <span class="str">'opacity 180ms ease'</span>`,
+
+  "spring-config": `<span class="cm">// Verlet integration — position + velocity per frame</span>
+<span class="kw">const</span> <span class="fn">tick</span> = () => {
+  <span class="kw">const</span> force =
+    -stiffness * (pos - target)  <span class="cm">// restore</span>
+    - damping * vel              <span class="cm">// resist</span>
+  acc = force / mass
+  vel += acc * dt
+  pos += vel * dt
+  <span class="fn">requestAnimationFrame</span>(tick)
+}
+
+<span class="cm">// Critical damping: no oscillation</span>
+<span class="cm">// damping = 2 × √(stiffness × mass)</span>
+<span class="cm">// Under-damped: bouncy  Over-damped: sluggish</span>`,
+
+  "flip-list": `<span class="cm">// FLIP: First → Last → Invert → Play</span>
+
+<span class="cm">// 1. Record First positions</span>
+els.<span class="fn">forEach</span>((el, key) =>
+  prev.<span class="fn">set</span>(key, el.<span class="fn">getBoundingClientRect</span>()))
+
+<span class="cm">// 2. Mutate state — DOM moves to Last</span>
+<span class="fn">setOrder</span>(<span class="fn">shuffle</span>(order))
+
+<span class="cm">// 3. Invert: apply transform to Last → First</span>
+<span class="kw">const</span> dy = old.top - cur.top
+el.style.transform = \`translateY(\${dy}px)\`
+el.style.transition = <span class="str">'none'</span>
+
+<span class="cm">// 4. Play: remove transform, let CSS animate to 0</span>
+<span class="fn">requestAnimationFrame</span>(() => {
+  el.style.transform = <span class="str">''</span>
+  el.style.transition = <span class="str">'transform 380ms cubic-bezier(.34,1.2,.64,1)'</span>
+})`,
+
+  "focus-ring": `<span class="cm">/* Custom focus ring — outline, never box-shadow */</span>
+:focus-visible {
+  <span class="cm">/* outline composites correctly; box-shadow clips */</span>
+  <span class="prop">outline</span>: <span class="num">2px</span> solid var(--accent);
+  <span class="prop">outline-offset</span>: <span class="num">2px</span>;
+  <span class="prop">box-shadow</span>: <span class="num">0 0 0 4px</span>
+    color-mix(<span class="kw">in</span> oklch, var(--accent) <span class="num">18%</span>, transparent);
+}
+
+<span class="cm">/* Pill gets a pill ring */</span>
+.<span class="fn">btn-pill</span>:focus-visible {
+  <span class="prop">outline-offset</span>: <span class="num">3px</span>;
+  <span class="prop">border-radius</span>: <span class="num">100px</span>;
+}
+
+<span class="cm">/* Always use :focus-visible, not :focus */</span>
+<span class="cm">/* :focus fires on click; :focus-visible only on keyboard */</span>`,
 };
 
 const DEMOS: Record<ExpId, React.FC> = {
+  oklch: OklchDemo,
+  "fluid-type": FluidTypeDemo,
   "var-font": VarFontDemo,
-  bento: BentoDemo,
-  "scroll-progress": ScrollProgressDemo,
   "spring-btn": SpringBtnDemo,
   "cursor-trail": CursorTrailDemo,
   "tilt-card": TiltCardDemo,
   cmd: CmdDemo,
   mag: MagDemo,
-  cnt: CntDemo,
-  stk: StkDemo,
   "noise-btn": NoiseBtnDemo,
-  scramble: ScrambleDemo,
-  abb: AbbDemo,
   "seg-ctrl": SegCtrlDemo,
   toast: ToastDemo,
   drag: DragDemo,
   checkbox: CheckboxDemo,
   dock: DockDemo,
   island: IslandDemo,
+  "spring-config": SpringConfigDemo,
+  "flip-list": FlipListDemo,
+  "focus-ring": FocusRingDemo,
 };
 
 export const EXPERIMENT_SLUGS: Record<ExpId, string> = {
+  oklch: "oklch-color",
+  "fluid-type": "fluid-typography",
   "var-font": "variable-font-morph",
-  bento: "bento-grid",
-  "scroll-progress": "scroll-linked-progress",
   "spring-btn": "spring-physics-button",
   "cursor-trail": "cursor-trail",
   "tilt-card": "tilt-card",
   cmd: "command-menu",
   mag: "magnetic-button",
-  cnt: "animated-counter",
-  stk: "image-stack",
   "noise-btn": "noise-button",
-  scramble: "text-scramble",
-  abb: "apple-bottom-bar",
   "seg-ctrl": "segmented-control",
   toast: "toast-notifications",
   drag: "drag-to-dismiss",
   checkbox: "checkbox-animation",
   dock: "macos-dock",
   island: "dynamic-island",
+  "spring-config": "spring-configurator",
+  "flip-list": "flip-animation",
+  "focus-ring": "focus-ring-system",
 };
 
 export function getExperimentPath(exp: Exp) {

--- a/content/experiments/command-menu.mdx
+++ b/content/experiments/command-menu.mdx
@@ -1,0 +1,20 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="cmd" />
+
+The command palette is the senior engineer's shortcut mechanism — it assumes the user knows what they want and just needs a fast path to it. The design challenge isn't the palette itself, it's teaching users it exists. Apple did it by making Spotlight the system-wide affordance. Linear brought it to web apps. Now it's table stakes.
+
+**Fuzzy matching.** The filter isn't substring search — it's subsequence matching. For each query character, find the next occurrence in the target string. `"git"` matches `"Open GitHub"` because g, i, t appear in order. This means users can type the letters they remember, not the exact start of the item name. The algorithm is O(n×m) per item, negligible for ≤200 items.
+
+**Grouped results.** Items are bucketed into Navigation, Links, Experiments, Settings. Groups separate conceptually different actions without hiding any results. The active index is a flat count across all groups — arrow keys navigate the flat list, but the visual presentation is grouped. This is a common source of bugs: index-into-groups vs index-into-flat-list.
+
+**The animation.** The palette enters from below at `translateY(8px)` with `opacity: 0`, settling to `translateY(0)` and `opacity: 1`. The backdrop blur (`backdrop-filter: blur(8px)`) uses a CSS class toggle so the browser can schedule the paint. Using inline style for backdrop-filter on every render can cause layout thrash on slower devices.
+
+**Why no Cmd+K global listener here.** In a full implementation you'd attach a `keydown` listener on `window` in a `useEffect`. In this embedded demo, the trigger is a visible button to avoid hijacking the user's browser shortcuts mid-page. In a real app this would be wired: `if ((e.metaKey || e.ctrlKey) && e.key === 'k') { e.preventDefault(); open() }`.
+
+<Callout type="insight">
+cmdk by Rauno Fröberg is the canonical open-source implementation of this pattern. Worth reading the source — the virtualization, the ARIA handling, and the composable group API are all well-considered. This demo is a teaching simplification; for production use the real library.
+</Callout>
+
+<ExperimentSourceBlock id="cmd" />

--- a/content/experiments/drag-to-dismiss.mdx
+++ b/content/experiments/drag-to-dismiss.mdx
@@ -1,0 +1,20 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="drag" />
+
+Every mobile bottom sheet — iOS sheets, Android bottom sheets, Sonner toasts on mobile — uses this model. Drag down to dismiss. But the naive implementation (dismiss when `y > threshold`) feels wrong in two ways: a slow deliberate drag gets ignored if it doesn't reach the threshold, and a fast flick gets ignored even though the intent was obvious.
+
+**The two-signal model.** The dismiss condition is `distance > 80px OR velocity > 0.5px/ms`. Either signal alone triggers dismissal. A fast flick at 20px distance reads as "throw away." A slow drag past 80px reads as "move aside." Both feel correct.
+
+**Pointer capture.** `setPointerCapture(pointerId)` on pointerdown is the critical call. Without it, if the pointer leaves the element boundary during a drag, the pointermove events stop firing — so the card freezes mid-drag and releases incorrectly when the pointer returns. Capture routes all subsequent pointer events to the element regardless of position. This is how every native drag gesture works under the hood.
+
+**Rubber-banding upward.** Dragging past the top edge applies `rawY × 0.18` instead of `rawY`. The 0.18 multiplier is chosen to feel like elastic resistance — each pixel of input produces 18% of a pixel of movement. iOS uses roughly this same ratio for overscroll rubber-banding.
+
+**Velocity measurement.** Velocity is `(currentY - lastY) / (currentTime - lastTime)` measured on every pointermove. The value at pointerup is the release velocity. This degrades gracefully: slow devices that fire fewer events get a coarser velocity reading, but it's still directionally correct.
+
+<Callout type="insight">
+The spring return (`cubic-bezier(.23, 1, .32, 1)`) on abandoned drags uses the same curve as the magnetic button's return. This isn't coincidence — it's a system decision. All spring-return interactions on this site use this curve. Consistency across interactions builds a subconscious sense of physical coherence.
+</Callout>
+
+<ExperimentSourceBlock id="drag" />

--- a/content/experiments/dynamic-island.mdx
+++ b/content/experiments/dynamic-island.mdx
@@ -1,0 +1,20 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="island" />
+
+Apple's Dynamic Island isn't a feature — it's a notch with good PR. The engineering insight is that a rounded rectangle can become a container for ambient information if the transitions feel physical enough that you stop thinking of it as a UI element.
+
+**The shape constraint.** Every state — idle pill, incoming call, download progress, navigation, message — is a single `div` with `border-radius: 100px`. No clip-path switches, no hidden second layer that reveals on expand. Width and height animate together. That constraint is the whole trick: the pill doesn't open, it *breathes*.
+
+**Why the spring matters.** `cubic-bezier(.34, 1.15, .64, 1)` gives roughly 8% overshoot. Enough to register as physical, not enough to feel bouncy. If you use the button-press spring (`.34, 1.56, .64, 1`) it reads as playful — wrong for a notification container. If you use `ease-out` it reads as a UI panel appearing — also wrong. The specific overshoot is load-bearing.
+
+**The content timing problem.** If content fades in as the shape is still distorting, letters look squeezed. The fix is a 120ms delay on the opacity transition — by the time text appears, the morph has mostly completed. This is the same principle behind iOS app launches: the icon scales before the interface loads, so you never see content inside a distorting frame.
+
+**Five states.** Incoming call with an audio waveform that animates. Morning alarm with dismiss/snooze actions. File download with a radial SVG progress ring. Turn-by-turn navigation with ETA. Incoming message preview. Each state returns to idle after 3.6 seconds automatically.
+
+<Callout type="insight">
+The download state's progress ring is drawn with `stroke-dasharray` and `stroke-dashoffset` on an SVG circle. The math: circumference = 2π × r. Offset = circumference × (1 − progress). This is the same technique as the checkbox experiment — two completely different-feeling interactions share identical SVG mechanics.
+</Callout>
+
+<ExperimentSourceBlock id="island" />

--- a/content/experiments/flip-animation.mdx
+++ b/content/experiments/flip-animation.mdx
@@ -1,0 +1,24 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="flip-list" />
+
+When you shuffle the list, each item appears to glide to its new position. No absolute positioning, no `left`/`top` animation, no layout engine. The DOM reorders instantly; the animation is a visual lie. This is FLIP.
+
+**First.** Before mutating state, record the bounding box of every element: `el.getBoundingClientRect()`. Store keyed to item identity, not index.
+
+**Last.** Mutate state — React re-renders, the DOM reflects the new order. Items have moved to their final positions.
+
+**Invert.** Now compute `delta = first.top - last.top` for each element. Apply a CSS transform that puts the element visually *back* in its First position: `transform: translateY(delta)`. Apply it with `transition: none` so it snaps immediately without animating.
+
+**Play.** Remove the transform in the next `requestAnimationFrame`, restoring the element to its Last position. Add the transition: `transform 380ms spring`. The browser animates from the inverted-First to the real-Last (zero transform). The user sees motion; the layout never moved.
+
+**Why `key` matters.** FLIP requires stable element identity across renders. React's `key` prop ensures the same DOM node is reused for the same list item. Without stable keys, React unmounts the old node and mounts a new one — no node to apply the inversion to.
+
+**The double `requestAnimationFrame`.** Applying the transform and then removing it in the same frame is a race condition — the browser may batch the style changes and never render the inverted state. Two nested rAFs guarantee the inversion is painted before the transition starts.
+
+<Callout type="insight">
+This technique works for any layout change — grid reflows, accordion expands, list filter results. The View Transitions API automates FLIP for navigations and full-page state changes. For in-component animation, manual FLIP remains more controllable than the platform API.
+</Callout>
+
+<ExperimentSourceBlock id="flip-list" />

--- a/content/experiments/fluid-typography.mdx
+++ b/content/experiments/fluid-typography.mdx
@@ -1,0 +1,30 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="fluid-type" />
+
+Drag the viewport slider. The heading, body, and caption all scale simultaneously, each on its own curve. There are no media query breakpoints. The font size is a continuous function of the viewport width.
+
+**The formula.** `clamp(min, preferred, max)` where `preferred = min + (max - min) × ((100vw - minVW) / (maxVW - minVW))`. This is linear interpolation between `min` at `minVW` and `max` at `maxVW`, clamped so it never exceeds either bound. Expanded:
+
+```css
+font-size: clamp(
+  1.75rem,
+  calc(1.75rem + 1.5 * ((100vw - 20rem) / 55)),
+  3.25rem
+);
+```
+
+The division `(100vw - 20rem) / 55` normalizes the viewport to a 0–1 range. Multiply by the size delta. Add the minimum. Clamp.
+
+**Why not just `vw` units.** Pure `font-size: 4vw` has no bounds — it's too small at 320px and enormous at 2560px. `clamp()` adds the min and max guardrails that make fluid type usable in practice.
+
+**Scale steps, not arbitrary sizes.** The heading, body, and caption don't scale by the same amount — each has its own slope. The heading changes by 24px across the range; the body changes by 3px. At narrow viewports, the type hierarchy compresses toward a single size (all levels become more similar). At wide viewports, it expands for visual drama. This is intentional — the hierarchy should feel proportionate at every width.
+
+**Generating the values.** Tools like Utopia.fyi generate the `clamp()` values from a type scale ratio and viewport range. The underlying math is what's above. Understanding the formula means you can override the tool when the scale needs non-standard steps.
+
+<Callout type="insight">
+Fluid typography and fluid spacing together define a layout that scales continuously. Define the type scale in `rem` using `clamp()`. Define spacing tokens the same way. The result is a design system with no breakpoints — the layout responds to every viewport width, not just the three you chose.
+</Callout>
+
+<ExperimentSourceBlock id="fluid-type" />

--- a/content/experiments/focus-ring-system.mdx
+++ b/content/experiments/focus-ring-system.mdx
@@ -1,0 +1,20 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="focus-ring" />
+
+Tab through the four elements. Each gets a focus indicator tuned to its shape. The pill button gets a pill ring. The input gets a rectangular ring. The link gets an underline. The card gets a rectangular ring with the same offset as the input.
+
+**Why not `box-shadow`.** `box-shadow` is drawn inside the stacking context and can be clipped by `overflow: hidden` on a parent. `outline` composites at the painting layer — it's drawn over all content, never clipped. For focus rings that need to be reliable across arbitrary DOM contexts, `outline` is correct.
+
+**`outline-offset`.** The gap between the element's edge and the ring. Pill button: 3px, giving visual breathing room around the rounded corners. Square elements: 2px, which looks tighter and more precise. The offset is part of the design — not a default to leave at zero.
+
+**The glow.** `box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent) 18%, transparent)` adds a soft aura without blur. The `color-mix` in OKLCH ensures the glow hue matches the accent correctly across light and dark modes. Using `rgba(accent, 0.18)` works in simple cases but fails when the accent color changes between themes.
+
+**`:focus-visible` not `:focus`.** `:focus` fires on any focus event — including mouse clicks. That means every button press shows a focus ring, which feels noisy. `:focus-visible` fires only when the browser determines keyboard navigation is happening. This is the correct default for accessible, non-distracting focus design.
+
+<Callout type="insight">
+The WCAG 2.1 focus visible criterion (2.4.7) requires focus to be visible. WCAG 2.2 adds enhanced criteria (2.4.11, 2.4.12) about minimum size and contrast. A 2px outline at the accent color with the 4px glow passes all three. Browser defaults (the blue ring) often fail contrast requirements on dark surfaces — never rely on them.
+</Callout>
+
+<ExperimentSourceBlock id="focus-ring" />

--- a/content/experiments/macos-dock.mdx
+++ b/content/experiments/macos-dock.mdx
@@ -1,0 +1,26 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="dock" />
+
+The macOS Dock magnification is one of those interactions that looks simple until you try to replicate it. A naive version — scale the hovered icon to 1.8 — produces a jerky, isolated zoom with no relationship between adjacent icons. Apple's version feels like pushing a bubble through water: the disturbance propagates outward.
+
+**The Gaussian.** Scale at position `i` is:
+
+```
+scale(i) = 1 + (MAX − 1) × e^(−distance² / σ²)
+```
+
+`e^(−x²)` is the standard normal distribution curve. At distance zero, scale is MAX (1.72). At distance σ, scale drops to `1 + (MAX − 1) / e` — about 1.26 for this σ. At 2σ it's nearly 1. The icons don't zoom discretely; they participate in a continuous field.
+
+**Choosing σ.** σ = 58px gives a spread roughly two icon-widths wide. Set it to 30 and the falloff is so steep the effect looks like the naive version. Set it to 100 and the whole dock shifts simultaneously. 58 is where it starts feeling like a physical material.
+
+**The vertical offset.** Icons scale from their bottom edge, not their centre — `transform-origin: bottom center` on each, plus `translateY(-(scale - 1) × size × 0.5)` to lift the icon so its bottom stays on the shelf. Without this, scaling from centre causes the bottom to move down and the icon appears to sink into the shelf.
+
+**On mouseleave.** The transition during hover is `60ms ease` — fast enough to track without lag. On leave, it switches to `220ms cubic-bezier(.23, 1, .32, 1)` — a gentle spring return. The asymmetry is deliberate: the response time should match the input device's expected latency.
+
+<Callout type="insight">
+This is pure CPU math per frame — `Math.exp` on every mouse move for every icon. On a 120Hz display that's ~120 calls × 7 icons per second. It's fast enough to not matter, but a production version would use a lookup table or compute the scale in a CSS custom property updated via JS, letting the GPU handle the transform.
+</Callout>
+
+<ExperimentSourceBlock id="dock" />

--- a/content/experiments/oklch-color.mdx
+++ b/content/experiments/oklch-color.mdx
@@ -1,0 +1,20 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="oklch" />
+
+Drag the hue sliders until the endpoints are complementary — purple and green, or blue and orange. The top gradient (sRGB) passes through a grey, washed-out midpoint. The bottom (OKLCH) stays vivid throughout. This is the fundamental problem OKLCH solves.
+
+**Why sRGB fails.** RGB is an encoding format, not a perceptual space. Interpolating between `hsl(260, 70%, 55%)` and `hsl(160, 70%, 55%)` in sRGB means traversing through hues near green that happen to have lower perceived luminosity — so the midpoint looks dim even though the lightness value is identical. The human visual system has non-uniform sensitivity across hues.
+
+**What OKLCH does.** OKLab (and its cylindrical form OKLCH) was designed so that moving equal distances in the color space produces equal-looking changes. The L axis is perceptual lightness — L=0.65 looks equally bright whether the hue is blue, green, or red. When you interpolate between two OKLCH values at the same L and C, every step looks equally vivid.
+
+**The browser support story.** `oklch()` in CSS landed in Chrome 111, Firefox 113, Safari 15.4. The `color-mix(in oklch, ...)` function works the same way for blending. As of 2025, you can ship OKLCH to production without a fallback for >95% of users. The `@supports (color: oklch(0 0 0))` guard handles the rest.
+
+**This demo's implementation.** Native CSS `oklch()` in gradients handles the interpolation automatically in supported browsers. The JS fallback manually converts OKLCH → OKLab → linear sRGB → gamma-corrected sRGB to produce the stepped gradient for the comparison row. The conversion matrix comes from the OKLab spec.
+
+<Callout type="insight">
+The reason OKLCH matters for design systems: when you define a color palette step (gray-50 through gray-900), each step should feel equally spaced in perceived lightness. sRGB steps don't. OKLCH steps do. Radix UI, Tailwind v4, and Linear all now generate their palettes in perceptual space.
+</Callout>
+
+<ExperimentSourceBlock id="oklch" />

--- a/content/experiments/registry.ts
+++ b/content/experiments/registry.ts
@@ -1,0 +1,17 @@
+import type { ComponentType } from "react";
+
+type MDXImporter = () => Promise<{ default: ComponentType }>;
+
+export const experimentContent: Partial<Record<string, MDXImporter>> = {
+  "dynamic-island": () => import("./dynamic-island.mdx"),
+  "macos-dock": () => import("./macos-dock.mdx"),
+  "drag-to-dismiss": () => import("./drag-to-dismiss.mdx"),
+  "command-menu": () => import("./command-menu.mdx"),
+  "spring-configurator": () => import("./spring-configurator.mdx"),
+  "oklch-color": () => import("./oklch-color.mdx"),
+  "fluid-typography": () => import("./fluid-typography.mdx"),
+  "flip-animation": () => import("./flip-animation.mdx"),
+  "tilt-card": () => import("./tilt-card.mdx"),
+  "variable-font-morph": () => import("./variable-font-morph.mdx"),
+  "focus-ring-system": () => import("./focus-ring-system.mdx"),
+};

--- a/content/experiments/spring-configurator.mdx
+++ b/content/experiments/spring-configurator.mdx
@@ -1,0 +1,20 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="spring-config" />
+
+Every animation on this site driven by a spring uses three parameters: stiffness, damping, and mass. This experiment makes those parameters tangible. The ball bounces; the curve plots the position over time.
+
+**Stiffness** is the restoring force — how strongly the spring pulls the object toward its target. High stiffness (400+) produces fast, snappy responses. Low stiffness (50) produces slow, floaty movement. When stiffness is very high without proportional damping, the spring overshoots violently.
+
+**Damping** is the resistive force — friction, air resistance. It opposes velocity. Low damping lets the spring oscillate many times before settling. The critical damping value — where the object reaches its target in minimum time without oscillating — is `2 × √(stiffness × mass)`. CSS cubic-bezier springs are always critically or over-damped. Framer Motion's `type: "spring"` can be under-damped.
+
+**Mass** slows everything proportionally. Higher mass makes the spring feel heavier — slower acceleration, slower deceleration, same number of oscillations. In UI: mass is the tool for making something feel weighty without making it feel unresponsive.
+
+**The implementation uses Verlet integration**, not a physics engine. Each frame: compute the restoring force (`-stiffness × displacement`) and damping force (`-damping × velocity`), sum them, divide by mass to get acceleration, integrate velocity and position with `dt = 1/60`. This is the same math Framer Motion uses internally — the cubic-bezier is just a pre-computed approximation of this simulation.
+
+<Callout type="insight">
+Most of this site's spring animations use stiffness=200, damping=18 — slightly under-damped, with about 15% overshoot. The dock uses stiffness=120, damping=14 (gentler). The checkbox uses stiffness=300, damping=22 (snappier). The numbers sound arbitrary, but they encode a coherent set of physical sensations: every element belongs to the same imagined physical world.
+</Callout>
+
+<ExperimentSourceBlock id="spring-config" />

--- a/content/experiments/tilt-card.mdx
+++ b/content/experiments/tilt-card.mdx
@@ -1,0 +1,20 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="tilt-card" />
+
+3D tilt on hover has been done badly so many times that it reads as a gimmick. Done well, it reads as physical — the card occupies space, light behaves correctly, and the return feels like an object settling.
+
+**The rotation math.** Normalize the cursor position to `[0, 1]` within the card, then shift to `[-0.5, 0.5]`. Multiply by the max rotation angle (14°). `rotateX` maps to the Y axis of the cursor (how far up or down). `rotateY` maps to the X axis. The signs are chosen so the card tilts *toward* the cursor — near the top-right corner, the card tilts top-right.
+
+**The specular highlight.** A `radial-gradient` centered at `(cursorX%, cursorY%)` with `mix-blend-mode: overlay` simulates a light source. Overlay blends luminosity — bright parts get brighter, dark parts get darker. The gradient center follows the cursor, so the bright spot tracks the "light." Most tilt card implementations miss this or implement it as a fixed-position shimmer, which reads as fake.
+
+**The shadow.** Box shadow shifts opposite to the tilt direction: `${-tiltY * 0.6}px ${tiltX * 0.6}px`. When the card tilts right (rotateY positive), the shadow shifts left. This reinforces the 3D illusion — the shadow projects away from the light source.
+
+**On mouseleave.** The transition switches from `none` (during tracking) to `500ms cubic-bezier(.25,.46,.45,.94)`. No transition during movement keeps the card responsive; the spring only applies on return. This asymmetry is why it feels physical rather than floaty.
+
+<Callout type="insight">
+`perspective: 700px` on the parent sets how dramatic the 3D effect appears. Lower values (400px) exaggerate the perspective distortion at high tilt angles. Higher values (1200px) make the effect subtle. 700px is roughly the viewing distance for a laptop screen, making the perspective feel geometrically accurate.
+</Callout>
+
+<ExperimentSourceBlock id="tilt-card" />

--- a/content/experiments/variable-font-morph.mdx
+++ b/content/experiments/variable-font-morph.mdx
@@ -1,0 +1,20 @@
+import { ExperimentDemoBlock, ExperimentSourceBlock } from "@/components/sections/Experiments";
+import { Callout } from "@/components/mdx/Callout";
+
+<ExperimentDemoBlock id="var-font" />
+
+Variable fonts embed multiple instances of a typeface in a single file. The `wght` axis is the most common — a single font file contains every weight from 100 to 900. This experiment makes that axis tactile.
+
+**`font-variation-settings`.** This CSS property directly addresses font axes by their four-character tag. `'wght' 600` sets the weight axis to 600. Unlike `font-weight`, which maps to discrete named stops, `font-variation-settings` accepts any value the axis supports — including 347, or 812.5.
+
+**The easing curve.** `cubic-bezier(.34, 1.3, .64, 1)` has an overshoot — the weight briefly exceeds 800 before settling. On a variable font this is visible: the text momentarily appears heavier than the target weight, then relaxes. This is what makes it feel alive rather than mechanical.
+
+**Transitioning font axes.** CSS `transition: font-variation-settings 400ms cubic-bezier(...)` works on all modern browsers. The browser interpolates between the two axis values, rendering every intermediate weight. The font file doesn't contain these intermediate renders — the OpenType engine generates them on the fly from the variation data.
+
+**The range slider.** Drag the slider to explore any weight between 100 and 900. At 100, the strokes are hairline-thin. At 900, the letterforms fill their space. This is the design space the type designer defined — one file, infinite weights.
+
+<Callout type="insight">
+Variable fonts support multiple axes beyond weight: `wdth` (width), `ital` (italic), `slnt` (slant), `opsz` (optical size), and custom axes defined by the typeface. The Inter font supports `wght` and `opsz`. Recursive supports `MONO`, `CRSV`, and more. The axis count determines how much of the design space is navigable with CSS alone.
+</Callout>
+
+<ExperimentSourceBlock id="var-font" />


### PR DESCRIPTION
## Summary

- **Remove 6 shallow experiments**: Bento Grid, Scroll Progress, Animated Counter, Image Stack, Apple Bottom Bar, Text Scramble — each was visually passable but technically uninteresting or too commonly seen
- **Add 5 new experiments** targeting design-engineering depth:
  - **OKLCH Color Mixer** — side-by-side sRGB vs OKLCH gradient comparison, interactive hue sliders, full OKLCH→sRGB conversion in JS fallback
  - **Fluid Typography** — CSS `clamp()` type scale with a live viewport slider; shows how heading/body/caption scale independently
  - **Spring Configurator** — Verlet integration visualizer; tune stiffness/damping/mass, see the position curve plotted alongside the animated ball
  - **FLIP Animation** — list reorder using First/Last/Invert/Play; demonstrates the double-rAF technique and why stable `key` props matter
  - **Focus Ring System** — tab through 4 element types, each with a shape-tuned ring using `outline` (not `box-shadow`), WCAG-compliant
- **Per-experiment MDX architecture**: `content/experiments/registry.ts` maps slugs to MDX importers. `[slug]/page.tsx` checks the registry and falls back to the data-driven `ExperimentDetailPage`. `generateStaticParams` added.
- **Write-ups for 11 experiments**: Dynamic Island, macOS Dock, Drag to Dismiss, Command Menu, Spring Configurator, OKLCH, Fluid Typography, FLIP, Tilt Card, Variable Font, Focus Ring. Each surfaces the non-obvious reasoning — spring curve selection, Gaussian math, pointer capture semantics, OKLCH conversion matrices, WCAG focus criteria.
- **`<Callout>` component** for insight callouts inside MDX

## Architecture notes

The MDX registry pattern means adding a write-up for any existing experiment is just: create `content/experiments/[slug].mdx` and add an entry to `registry.ts`. No changes to routing or data required.

Experiments without a registry entry still work — they fall through to the interactive demo + source code block.

## Reviewer notes

- TypeScript passes cleanly (`tsc --noEmit`)
- The OKLCH JS fallback does a manual OKLCH→OKLab→linear sRGB→gamma sRGB conversion for the comparison gradient. Native `oklch()` in CSS handles the real gradient in supporting browsers.
- Spring Configurator uses Verlet integration at 1/60s timestep — same math as Framer Motion's spring implementation.