### PR TITLE
Site-wide top nav with count badges, Claude-app art direction

### DIFF
--- a/app/experiments/page.tsx
+++ b/app/experiments/page.tsx
@@ -1,26 +1,24 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import ThemeToggle from "@/components/ui/ThemeToggle";
+import SiteNav from "@/components/sections/SiteNav";
 import Experiments from "@/components/sections/Experiments";
 import Footer from "@/components/sections/Footer";
+import { EXPERIMENT_META } from "@/components/sections/experiments-data";
+
+const experimentsCount = Object.keys(EXPERIMENT_META).length;
 
 export const metadata: Metadata = {
   title: "Experiments - Tatenda Chinyamakobvu",
-  description:
-    "18 interactive UI studies: spring physics, perceptual color, fluid typography, and interaction patterns.",
+  description: `${experimentsCount} interactive UI studies: spring physics, perceptual color, fluid typography, and interaction patterns.`,
 };
 
 export default function ExperimentsPage() {
   return (
     <>
       <div className="wrap">
-        <div className="exp-page-header">
-          <ThemeToggle />
-          <Link href="/" className="exp-back">
-            Home
-          </Link>
-          <h1 className="exp-page-title">Experiments</h1>
-          <p className="exp-page-desc">
+        <SiteNav />
+        <div className="page-head">
+          <h1 className="page-title">Experiments</h1>
+          <p className="page-desc">
             Interactive UI patterns. Select a study to inspect the demo and
             source.
           </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,10 @@
   --amber-bg: #FFFBEB;
   --shadow-sm: 0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
   --shadow-md: 0 4px 16px rgba(0,0,0,.08), 0 2px 6px rgba(0,0,0,.04);
+  --pill-bg: var(--bg-subtle);
+  --pill-fg: var(--fg-muted);
+  --pill-border: var(--border);
+  --dot-green: var(--green);
   --font-sans: 'Atkinson Hyperlegible', 'Helvetica Neue', sans-serif;
   --font-mono: 'Atkinson Hyperlegible Mono', 'SFMono-Regular', Consolas, monospace;
   --font-serif: 'Libertinus Serif', Georgia, serif;
@@ -93,13 +97,10 @@ header { opacity: 0; animation: fadeUp 400ms ease-out 40ms forwards; }
 /* --------------------------------------------
    HEADER
 -------------------------------------------- */
-header { padding: 88px 0 80px; position: relative; }
-@media(max-width: 640px) { header { padding: 56px 0 64px; } }
+header { padding: 56px 0 64px; position: relative; }
+@media(max-width: 640px) { header { padding: 40px 0 48px; } }
 .wordmark { display: flex; align-items: center; gap: 10px; margin-bottom: 20px; }
 .wordmark h1 { font-size: 17.5px; font-weight: 400; color: var(--fg); letter-spacing: 0; }
-.wordmark-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); flex-shrink: 0; box-shadow: 0 0 0 3px var(--green-bg); animation: pulse 2.4s ease-in-out infinite; }
-@keyframes pulse { 0%,100% { box-shadow: 0 0 0 3px var(--green-bg); } 50% { box-shadow: 0 0 0 5px var(--green-bg); } }
-[data-theme="dark"] .wordmark-dot { box-shadow: 0 0 0 3px rgba(74,222,128,.12); }
 .tagline { font-size: 17px; color: var(--fg-muted); margin-bottom: 24px; line-height: 1.55; }
 .bio { display: flex; flex-direction: column; gap: 8px; margin-bottom: 32px; }
 .bio p { font-size: 16.5px; color: var(--fg-muted); line-height: 1.75; }
@@ -109,13 +110,52 @@ header { padding: 88px 0 80px; position: relative; }
 .stat { display: flex; flex-direction: column; gap: 2px; }
 .stat-val { font-family: var(--font-serif); font-size: 22px; font-weight: 400; color: var(--fg); line-height: 1; letter-spacing: 0; }
 .stat-lbl { font-size: 14px; color: var(--fg-subtle); }
-.nav-links { display: flex; align-items: center; font-family: var(--font-mono); font-size: 14px; }
-.nav-links a { color: var(--fg-subtle); transition: color var(--t-fast), border-color var(--t-fast); padding: 3px 0; border-bottom: 1px solid transparent; }
-.nav-links a:hover { color: var(--fg); border-color: var(--border-hover); }
-.nav-sep { color: var(--border-hover); margin: 0 10px; user-select: none; }
 #theme-toggle { position: absolute; top: 88px; right: 0; background: none; border: none; cursor: pointer; padding: 4px; color: var(--fg-subtle); transition: color var(--t-fast); border-radius: 4px; display: flex; align-items: center; }
 #theme-toggle:hover { color: var(--fg); }
 @media(max-width: 640px) { #theme-toggle { top: 56px; } }
+
+/* --------------------------------------------
+   SITE NAV (top of every page)
+-------------------------------------------- */
+.site-nav { display: flex; align-items: center; gap: 28px; flex-wrap: wrap; padding: 28px 0; border-bottom: 1px solid var(--border); font-family: var(--font-mono); font-size: 13.5px; opacity: 0; animation: fadeUp 320ms ease-out forwards; }
+.site-nav-item { display: inline-flex; align-items: center; gap: 6px; color: var(--fg-muted); padding: 4px 0; transition: color var(--t-fast); white-space: nowrap; }
+.site-nav-item:hover { color: var(--fg); }
+.site-nav .ext-arrow { color: var(--fg-subtle); font-size: 12px; line-height: 1; transition: color var(--t-fast); }
+.site-nav-item:hover .ext-arrow { color: var(--fg-muted); }
+.site-nav .count-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 18px; padding: 1px 6px; border-radius: 999px; background: var(--pill-bg); border: 1px solid var(--pill-border); color: var(--pill-fg); font-family: var(--font-mono); font-size: 11.5px; line-height: 1.5; }
+.site-nav-spacer { flex: 1; }
+.site-nav #theme-toggle { position: static; top: auto; right: auto; padding: 2px; color: var(--fg-subtle); }
+.site-nav #theme-toggle:hover { color: var(--fg); }
+@media(max-width: 640px) {
+  .site-nav { gap: 14px 18px; font-size: 13px; padding: 20px 0; }
+  .site-nav-spacer { flex-basis: 100%; display: none; }
+  .site-nav #theme-toggle { margin-left: auto; }
+}
+
+/* --------------------------------------------
+   STATUS PILL (Claude-app style chip)
+-------------------------------------------- */
+.status-pill { display: inline-flex; align-items: center; gap: 6px; padding: 2px 10px 2px 8px; border-radius: 999px; background: var(--pill-bg); border: 1px solid var(--pill-border); color: var(--pill-fg); font-family: var(--font-mono); font-size: 12px; line-height: 1.6; white-space: nowrap; }
+.status-pill-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--dot-green); flex-shrink: 0; box-shadow: 0 0 0 3px var(--green-bg); animation: status-pulse 2.4s ease-in-out infinite; }
+@keyframes status-pulse { 0%,100% { box-shadow: 0 0 0 3px var(--green-bg); } 50% { box-shadow: 0 0 0 4px var(--green-bg); } }
+[data-theme="dark"] .status-pill-dot { box-shadow: 0 0 0 3px rgba(74,222,128,.12); }
+[data-theme="dark"] .status-pill-dot { animation-name: status-pulse-dark; }
+@keyframes status-pulse-dark { 0%,100% { box-shadow: 0 0 0 3px rgba(74,222,128,.12); } 50% { box-shadow: 0 0 0 4px rgba(74,222,128,.18); } }
+
+/* --------------------------------------------
+   CONTACT ROW (email + availability, below header content)
+-------------------------------------------- */
+.contact-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; padding-top: 24px; margin-top: 4px; border-top: 1px solid var(--border); }
+.contact-email { font-family: var(--font-mono); font-size: 14px; color: var(--fg-muted); padding: 3px 0; border-bottom: 1px solid transparent; transition: color var(--t-fast), border-color var(--t-fast); }
+.contact-email:hover { color: var(--fg); border-color: var(--border-hover); }
+
+/* --------------------------------------------
+   GENERIC PAGE HEAD (writing, experiments, photos)
+-------------------------------------------- */
+.page-head { padding: 56px 0 40px; opacity: 0; animation: fadeUp 400ms ease-out 40ms forwards; }
+@media(max-width: 640px) { .page-head { padding: 40px 0 32px; } }
+.page-title { font-size: 24px; font-weight: 400; letter-spacing: 0; color: var(--fg); line-height: 1.2; margin-bottom: 12px; }
+.page-desc { font-size: 14.5px; color: var(--fg-muted); line-height: 1.65; max-width: 56ch; }
 
 /* --------------------------------------------
    TAG

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import Header from "@/components/sections/Header";
+import SiteNav from "@/components/sections/SiteNav";
 import Projects from "@/components/sections/Projects";
 import Experience from "@/components/sections/Experience";
 import Awards from "@/components/sections/Awards";
 import Footer from "@/components/sections/Footer";
+import { EXPERIMENT_META } from "@/components/sections/experiments-data";
+import { posts } from "@/app/writing/posts";
 
 export const metadata: Metadata = {
   title: "Tatenda Chinyamakobvu — Product Engineer",
@@ -13,8 +16,12 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
+  const experimentsCount = Object.keys(EXPERIMENT_META).length;
+  const writingCount = posts.length;
+
   return (
     <div className="wrap">
+      <SiteNav />
       <Header />
       <Projects />
       <Experience />
@@ -23,7 +30,10 @@ export default function Page() {
         <Link href="/writing" className="exp-teaser-row">
           <div>
             <div className="exp-teaser-name">Writing</div>
-            <div className="exp-teaser-sub">Notes, debugging stories, and the occasional opinion</div>
+            <div className="exp-teaser-sub">
+              {writingCount} {writingCount === 1 ? "note" : "notes"} — debugging
+              stories, build logs, and the occasional opinion
+            </div>
           </div>
           <span className="exp-teaser-arrow">→</span>
         </Link>
@@ -41,7 +51,10 @@ export default function Page() {
         <Link href="/experiments" className="exp-teaser-row">
           <div>
             <div className="exp-teaser-name">Experiments</div>
-            <div className="exp-teaser-sub">18 interactive studies — physics, color, typography, interaction</div>
+            <div className="exp-teaser-sub">
+              {experimentsCount} interactive studies — physics, color,
+              typography, interaction
+            </div>
           </div>
           <span className="exp-teaser-arrow">→</span>
         </Link>

--- a/app/photos/page.tsx
+++ b/app/photos/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import Link from "next/link";
 import path from "path";
 import fs from "fs";
-import ThemeToggle from "@/components/ui/ThemeToggle";
+import SiteNav from "@/components/sections/SiteNav";
 import Footer from "@/components/sections/Footer";
 
 export const metadata: Metadata = {
@@ -20,13 +19,10 @@ export default function Page() {
   return (
     <>
       <div className="wrap">
-        <div className="exp-page-header">
-          <ThemeToggle />
-          <Link href="/" className="exp-back">
-            Home
-          </Link>
-          <h1 className="exp-page-title">Photos</h1>
-          <p className="exp-page-desc">
+        <SiteNav />
+        <div className="page-head">
+          <h1 className="page-title">Photos</h1>
+          <p className="page-desc">
             A small archive — favourite people, pups, and moments worth keeping.
           </p>
         </div>

--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -1,36 +1,14 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import ThemeToggle from "@/components/ui/ThemeToggle";
+import SiteNav from "@/components/sections/SiteNav";
 import Footer from "@/components/sections/Footer";
+import { posts, type Post } from "./posts";
 
 export const metadata: Metadata = {
   title: "Writing — Tatenda Chinyamakobvu",
   description:
     "Notes, debugging stories, and short essays from a product engineer in Zimbabwe.",
 };
-
-type Post = {
-  slug: string;
-  title: string;
-  date: string;
-  year: string;
-  topic: string;
-  readTime: string;
-  excerpt: string;
-};
-
-const posts: Post[] = [
-  {
-    slug: "fixing-wsl-localhost-issues",
-    title: "Fixing WSL localhost & port forwarding issues",
-    date: "Oct 22",
-    year: "2025",
-    topic: "Debugging",
-    readTime: "1 min",
-    excerpt:
-      "The smallest fix for the most annoying WSL2 networking bug — disable Fast Startup.",
-  },
-];
 
 function groupByYear(items: Post[]) {
   const map = new Map<string, Post[]>();
@@ -47,13 +25,10 @@ export default function WritingPage() {
   return (
     <>
       <div className="wrap">
-        <div className="exp-page-header">
-          <ThemeToggle />
-          <Link href="/" className="exp-back">
-            Home
-          </Link>
-          <h1 className="exp-page-title">Writing</h1>
-          <p className="exp-page-desc">
+        <SiteNav />
+        <div className="page-head">
+          <h1 className="page-title">Writing</h1>
+          <p className="page-desc">
             Notes from the day-to-day — debugging stories, build logs, and the
             occasional opinion. Written when something was annoying enough to
             need a record.

--- a/app/writing/posts.ts
+++ b/app/writing/posts.ts
@@ -1,0 +1,22 @@
+export type Post = {
+  slug: string;
+  title: string;
+  date: string;
+  year: string;
+  topic: string;
+  readTime: string;
+  excerpt: string;
+};
+
+export const posts: Post[] = [
+  {
+    slug: "fixing-wsl-localhost-issues",
+    title: "Fixing WSL localhost & port forwarding issues",
+    date: "Oct 22",
+    year: "2025",
+    topic: "Debugging",
+    readTime: "1 min",
+    excerpt:
+      "The smallest fix for the most annoying WSL2 networking bug — disable Fast Startup.",
+  },
+];

--- a/components/sections/Header.tsx
+++ b/components/sections/Header.tsx
@@ -1,16 +1,8 @@
-import ThemeToggle from "@/components/ui/ThemeToggle";
-
 export default function Header() {
   return (
     <header>
-      <ThemeToggle />
       <div className="wordmark">
         <h1>Tatenda Chinyamakobvu</h1>
-        <span
-          className="wordmark-dot"
-          aria-label="Available for work"
-          title="Available for work"
-        />
       </div>
       <p className="tagline">
         Product engineer. I care about the <em>parts most engineers skip</em>.
@@ -53,48 +45,15 @@ export default function Header() {
           <span className="stat-lbl">based in Zimbabwe</span>
         </div>
       </div>
-      <nav className="nav-links">
-        <a href="mailto:hi@chris.pagka.dev">hi@chris.pagka.dev</a>
-        <span className="nav-sep" aria-hidden="true">
-          /
-        </span>
-        <a href="/experiments">Experiments</a>
-        <span className="nav-sep" aria-hidden="true">
-          /
-        </span>
-        <a href="/writing">Writing</a>
-        <span className="nav-sep" aria-hidden="true">
-          /
-        </span>
-        <a
-          href="https://github.com/tate2301"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          GitHub
+      <div className="contact-row">
+        <a className="contact-email" href="mailto:hi@chris.pagka.dev">
+          hi@chris.pagka.dev
         </a>
-        <span className="nav-sep" aria-hidden="true">
-          /
+        <span className="status-pill" title="Available for work">
+          <span className="status-pill-dot" aria-hidden="true" />
+          Available for work
         </span>
-        {/* TODO: replace with your real Upwork profile URL */}
-        <a
-          href="https://www.upwork.com/freelancers/tatendachinyamakobvu"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Upwork
-        </a>
-        <span className="nav-sep" aria-hidden="true">
-          /
-        </span>
-        <a
-          href="https://twitter.com/atipamara"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          X
-        </a>
-      </nav>
+      </div>
     </header>
   );
 }

--- a/components/sections/SiteNav.tsx
+++ b/components/sections/SiteNav.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+import { EXPERIMENT_META } from "@/components/sections/experiments-data";
+import { posts } from "@/app/writing/posts";
+
+export default function SiteNav() {
+  const experimentsCount = Object.keys(EXPERIMENT_META).length;
+  const writingCount = posts.length;
+
+  return (
+    <nav className="site-nav" aria-label="Primary">
+      <Link href="/experiments" className="site-nav-item">
+        <span>Experiments</span>
+        <span className="count-badge">{experimentsCount}</span>
+      </Link>
+      <Link href="/writing" className="site-nav-item">
+        <span>Writing</span>
+        <span className="count-badge">{writingCount}</span>
+      </Link>
+      <Link href="/photos" className="site-nav-item">
+        <span>Photos</span>
+      </Link>
+      <a
+        href="https://github.com/tate2301"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="site-nav-item site-nav-ext"
+      >
+        <span>GitHub</span>
+        <span className="ext-arrow" aria-hidden="true">↗</span>
+      </a>
+      <a
+        href="https://www.upwork.com/freelancers/tatendachinyamakobvu"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="site-nav-item site-nav-ext"
+      >
+        <span>Upwork</span>
+        <span className="ext-arrow" aria-hidden="true">↗</span>
+      </a>
+      <a
+        href="https://twitter.com/atipamara"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="site-nav-item site-nav-ext"
+      >
+        <span>X</span>
+        <span className="ext-arrow" aria-hidden="true">↗</span>
+      </a>
+      <span className="site-nav-spacer" aria-hidden="true" />
+      <ThemeToggle />
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- Replace the cramped `.nav-links` row (email + 5 links with `/` separators and no mobile wrap) with a dedicated **`SiteNav`** rendered at the top of every page (`/`, `/writing`, `/experiments`, `/photos`).
- Move the email out of the nav into a **contact row** at the bottom of the header, paired with a Claude-app-style **`Available for work` status pill** (replaces the standalone pulsing wordmark dot).
- Add **count pill badges** next to *Experiments* (18) and *Writing* (1), driven dynamically by `EXPERIMENT_META` and a new shared `app/writing/posts.ts` module. Drops the stale hardcoded `"18 interactive studies"` from the homepage.
- Drift the design system toward the **Claude desktop app** aesthetic — restraint, generous whitespace, neutral pill chips, subtle dividers. Typography (Atkinson Hyperlegible) is intentionally unchanged; the feel is delivered through restraint, not a font swap.

## What changed

**New files**
- [`components/sections/SiteNav.tsx`](https://github.com/tate2301/atipamara/blob/nav-claude-app-style/components/sections/SiteNav.tsx) — top nav with pill-badge counts, `↗` glyphs for externals, theme toggle pushed to the right; wraps cleanly on mobile.
- [`app/writing/posts.ts`](https://github.com/tate2301/atipamara/blob/nav-claude-app-style/app/writing/posts.ts) — extracted posts array so the count is shareable.

**Edited**
- `components/sections/Header.tsx` — removed the inline `.nav-links` and `ThemeToggle`, added `.contact-row` with email + status pill.
- `app/page.tsx` / `app/writing/page.tsx` / `app/experiments/page.tsx` / `app/photos/page.tsx` — mount `<SiteNav />`, replace ad-hoc back-link/theme-toggle pairs with the unified nav, use generic `.page-head` styles.
- `app/globals.css` — new tokens (`--pill-bg`, `--pill-fg`, `--pill-border`, `--dot-green`); new `.site-nav`, `.count-badge`, `.status-pill`, `.contact-row`, `.page-head`; retired `.nav-links`, `.nav-sep`, `.wordmark-dot` and the related `pulse` keyframes. Tightened header padding now that SiteNav sits above it.

## Why

The previous nav had two real problems: it overflowed on narrow viewports (single flex row, no `flex-wrap`, no mobile breakpoint), and the email being inline with five external links made the focal "contact me" affordance hard to see. The user wanted nav links promoted to the top, the email left as a quieter element below, and the broader visual language nudged toward the Claude desktop app shown in their reference screenshot (restrained, pill-shaped status chips, calm neutrals).

## Notes for reviewer

- Individual writing post pages (`app/writing/(posts)/layout.tsx`) intentionally keep the legacy `.exp-back` style + absolute-positioned ThemeToggle — they're deeper-nav surfaces with a `← Writing` back link rather than the primary SiteNav. The `#theme-toggle` rule is overridden to `position: static` only inside `.site-nav`, so post pages still render the toggle in its existing top-right spot.
- The experiments badge reads **18** because `EXPERIMENT_META` registers 18 entries. There's a 19th file in `content/experiments/` (`article.mdx`) that isn't in the registry — likely intentional, but flagging in case you want it wired in to bump the count.
- `yarn.lock` had pre-existing un-staged changes from before this session and is **not** part of this PR.

## Test plan

- [ ] `pnpm dev` and visit `/` on desktop (≥1024px): nav appears at the top with `Experiments 18` / `Writing 1` pills, no `/` separators, theme toggle on the right.
- [ ] Resize to 375px: nav wraps to multiple rows with no horizontal overflow; all six items readable.
- [ ] Toggle dark mode via the in-nav theme button: pills, badges, and dividers stay legible.
- [ ] Click through to `/writing`, `/experiments`, `/photos` — same SiteNav at the top of each, consistent styling.
- [ ] Hover external links (GitHub, Upwork, X): subtle `↗` lifts to fg-muted; no blue accent on hover.
- [ ] Verify the contact row at the bottom of the header shows `hi@chris.pagka.dev` followed by a `● Available for work` pill.
- [ ] Visit `/writing/fixing-wsl-localhost-issues` — the individual post page still renders with its own back-link layout (no SiteNav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)